### PR TITLE
Allow arbitrary editing of json in captions studio

### DIFF
--- a/src/renderer/class/CaptionManager.js
+++ b/src/renderer/class/CaptionManager.js
@@ -73,7 +73,6 @@ class CaptionManager {
     if ($origin !== 'userOpen') {
       store.dispatch('setIsUnsavedChanges', { isUnsavedChanges: true });
     }
-
     Object.keys($event).forEach((key) => {
       $event[key].forEach((caption, index) => {
 
@@ -82,7 +81,9 @@ class CaptionManager {
         }
 
         const current = this.data[key];
-
+        if (!current) {
+          this.addCaption(key, $origin);
+        }
         this.data[key][index] = {
           content: caption.content || current.content,
           end: 'number' === typeof caption.end ? caption.end : current.end,

--- a/src/renderer/class/CaptionManager.js
+++ b/src/renderer/class/CaptionManager.js
@@ -73,6 +73,7 @@ class CaptionManager {
     if ($origin !== 'userOpen') {
       store.dispatch('setIsUnsavedChanges', { isUnsavedChanges: true });
     }
+
     Object.keys($event).forEach((key) => {
       $event[key].forEach((caption, index) => {
 
@@ -84,6 +85,7 @@ class CaptionManager {
         if (!current) {
           this.addCaption(key, $origin);
         }
+
         this.data[key][index] = {
           content: caption.content || current.content,
           end: 'number' === typeof caption.end ? caption.end : current.end,

--- a/src/renderer/components/caption-studio/JsonPreview.vue
+++ b/src/renderer/components/caption-studio/JsonPreview.vue
@@ -234,7 +234,7 @@ export default {
      * Updates current JSON data when CaptionManager emits the new caption data
      */
     update(data, $origin) {
-      // this.checkErrors(data, $origin);
+      this.checkErrors(data, $origin);
 
       this.data = this.cleanData(data);
       this.$refs.jsonEditor.editor.update(this.data);

--- a/src/renderer/components/caption-studio/JsonPreview.vue
+++ b/src/renderer/components/caption-studio/JsonPreview.vue
@@ -324,7 +324,7 @@ export default {
         }
         file.forEach((caption, index) => {
           if (caption.edited || $origin === this.origin) {
-            if (!caption.content || !caption.content.trim() ) {
+            if (!caption.content || !caption.content.trim()) {
               errors[key].push(`Error at caption [${key}], index [${index}]: Caption content must be non-empty`);
             }
             if ('number' !== typeof caption.start || caption.start < 0) {

--- a/src/renderer/components/caption-studio/JsonPreview.vue
+++ b/src/renderer/components/caption-studio/JsonPreview.vue
@@ -84,8 +84,8 @@ export default {
       activeFile: '',
       fileNameMap: {},
       options: {
-        onChangeJSON: this.onEdit,
-        mode: 'form',
+        onChangeText: this.onEdit,
+        mode: 'text',
         onEvent: this.onEvent
       },
     };
@@ -143,11 +143,8 @@ export default {
      * Handles JSON Editor changes
      */
     onEdit($event) {
-      this.checkErrors($event, this.origin);
-      if (this.jsonErrors) {
-        return;
-      }
-      EventBus.$emit('json_update', $event, this.origin);
+      this.checkErrors(JSON.parse($event), this.origin);
+      EventBus.$emit('json_update', JSON.parse($event), this.origin);
     },
     /**
      * Handles the save caption event from app menu or keyboard shortcut
@@ -237,7 +234,7 @@ export default {
      * Updates current JSON data when CaptionManager emits the new caption data
      */
     update(data, $origin) {
-      this.checkErrors(data, $origin);
+      // this.checkErrors(data, $origin);
 
       this.data = this.cleanData(data);
       this.$refs.jsonEditor.editor.update(this.data);
@@ -319,27 +316,27 @@ export default {
         errors[key] = [];
 
         const file = json[key];
-
         if (!Array.isArray(file)) {
           return;
         }
-
-        file.forEach((caption, index) => {
-          if (caption.edited || $origin === this.origin) {
-            if (!caption.content || !caption.content.trim()) {
-              errors[key].push(`Error at caption [${key}], index [${index}]: Caption content must be non-empty`);
+        if (file) {
+          file.forEach((caption, index) => {
+            if (caption.edited || $origin === this.origin) {
+              if (!caption.content || !caption.content.trim() ) {
+                errors[key].push(`Error at caption [${key}], index [${index}]: Caption content must be non-empty`);
+              }
+              if ('number' !== typeof caption.start || caption.start < 0) {
+                errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must have a positive number value`);
+              }
+              if ('number' !== typeof caption.end || caption.end < 0) {
+                errors[key].push(`Error at caption [${key}], index [${index}]: Caption end must have a positive number value`);
+              }
+              if (caption.start >= caption.end) {
+                errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must be less than the caption end`);
+              }
             }
-            if ('number' !== typeof caption.start || caption.start < 0) {
-              errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must have a positive number value`);
-            }
-            if ('number' !== typeof caption.end || caption.end < 0) {
-              errors[key].push(`Error at caption [${key}], index [${index}]: Caption end must have a positive number value`);
-            }
-            if (caption.start >= caption.end) {
-              errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must be less than the caption end`);
-            }
-          }
-        });
+          });
+        }
 
         if (errors[key].length <= 0) {
           delete errors[key];

--- a/src/renderer/components/caption-studio/JsonPreview.vue
+++ b/src/renderer/components/caption-studio/JsonPreview.vue
@@ -316,27 +316,28 @@ export default {
         errors[key] = [];
 
         const file = json[key];
+        if (!file) {
+          return;
+        }
         if (!Array.isArray(file)) {
           return;
         }
-        if (file) {
-          file.forEach((caption, index) => {
-            if (caption.edited || $origin === this.origin) {
-              if (!caption.content || !caption.content.trim() ) {
-                errors[key].push(`Error at caption [${key}], index [${index}]: Caption content must be non-empty`);
-              }
-              if ('number' !== typeof caption.start || caption.start < 0) {
-                errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must have a positive number value`);
-              }
-              if ('number' !== typeof caption.end || caption.end < 0) {
-                errors[key].push(`Error at caption [${key}], index [${index}]: Caption end must have a positive number value`);
-              }
-              if (caption.start >= caption.end) {
-                errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must be less than the caption end`);
-              }
+        file.forEach((caption, index) => {
+          if (caption.edited || $origin === this.origin) {
+            if (!caption.content || !caption.content.trim() ) {
+              errors[key].push(`Error at caption [${key}], index [${index}]: Caption content must be non-empty`);
             }
-          });
-        }
+            if ('number' !== typeof caption.start || caption.start < 0) {
+              errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must have a positive number value`);
+            }
+            if ('number' !== typeof caption.end || caption.end < 0) {
+              errors[key].push(`Error at caption [${key}], index [${index}]: Caption end must have a positive number value`);
+            }
+            if (caption.start >= caption.end) {
+              errors[key].push(`Error at caption [${key}], index [${index}]: Caption start must be less than the caption end`);
+            }
+          }
+        });
 
         if (errors[key].length <= 0) {
           delete errors[key];

--- a/src/renderer/components/caption-studio/JsonPreview.vue
+++ b/src/renderer/components/caption-studio/JsonPreview.vue
@@ -322,6 +322,7 @@ export default {
         if (!Array.isArray(file)) {
           return;
         }
+
         file.forEach((caption, index) => {
           if (caption.edited || $origin === this.origin) {
             if (!caption.content || !caption.content.trim()) {


### PR DESCRIPTION
- changed json preview `mode` from "form" to "text" (see https://github.com/josdejong/jsoneditor/blob/master/docs/api.md#configuration-options)
- changed callback from `onChangeJSON` to `onChangeText`
- support adding captions from json, not just editing existing captions